### PR TITLE
Changed path to the Lato-Medium font file.

### DIFF
--- a/Chapter Code/Chapter 13/JX11.jucer
+++ b/Chapter Code/Chapter 13/JX11.jucer
@@ -5,7 +5,7 @@
               pluginCode="JX11" cppLanguageStandard="17">
   <MAINGROUP id="oJCTC2" name="JX11">
     <GROUP id="{5B7D70C2-AF1C-A886-746F-59BB418603F7}" name="Resources">
-      <FILE id="GmOCTT" name="Lato-Medium.ttf" compile="0" resource="1" file="../Resources/Lato-Medium.ttf"/>
+      <FILE id="GmOCTT" name="Lato-Medium.ttf" compile="0" resource="1" file="../../Resources/Lato-Medium.ttf"/>
     </GROUP>
     <GROUP id="{06D34FFE-5C7B-FE1F-1632-1023D927248F}" name="Source">
       <FILE id="VNDAIT" name="Envelope.h" compile="0" resource="0" file="Source/Envelope.h"/>


### PR DESCRIPTION
Without this change, Projucer was looking in the "Chapter Code" directory for the font file.